### PR TITLE
remove unnecessary dependencies to reduce image size

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,15 +9,12 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
     echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk add --no-cache \
-      alpine-sdk \
       bash \
-      libstdc++ \
+      curl \
+      make \
       mono \
       mono-dev \
       mono-lang \
-      openssl-dev \
-      unzip \
-      vim \
       && \
     adduser -D user
 


### PR DESCRIPTION
Reduce image size from 498 MiB to 300 MiB.
The remaining dependencies are necessary to pass test harness.

Notes:
- bash and curl are needed for the microsoft install script(s).
- libstdc++ gets pulled in as a dependency of other packages.

Resolves jumanjihouse/docker-dotnet#6.

Thanks to @frol for the suggestion and @trumhemcut for the interest.
